### PR TITLE
fix(head): use ogp structured properties

### DIFF
--- a/quartz/components/Head.tsx
+++ b/quartz/components/Head.tsx
@@ -35,8 +35,8 @@ export default (() => {
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         {cfg.baseUrl && <meta property="og:image" content={ogImagePath} />}
-        <meta property="og:width" content="1200" />
-        <meta property="og:height" content="675" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="675" />
         <link rel="icon" href={iconPath} />
         <meta name="description" content={description} />
         <meta name="generator" content="Quartz" />


### PR DESCRIPTION
The <https://ogp.me> standard doesn't have an a property called "og:width" and "og:height".

The closest thing to that are "Structured Properties" for the image, which are actually "og:image:width" and "og:image:height".

This commit uses the correct property names.

For more information, read this excerpt from <https://ogp.me/#structured>:

> Some properties can have extra metadata attached to them. These are specified in the same way as other metadata with property and content, but the property will have extra :.
> 
> The og:image property has some optional structured properties:
> 
> - og:image:url - Identical to og:image.
> - og:image:secure_url - An alternate url to use if the webpage requires HTTPS.
> - og:image:type - A [MIME type](https://en.wikipedia.org/wiki/Internet_media_type) for this image.
> - og:image:width - The number of pixels wide.
> - og:image:height - The number of pixels high.
> - og:image:alt - A description of what is in the image (not a caption). If the page specifies an og:image it should specify og:image:alt.